### PR TITLE
Replace '/images' with '/images/'

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -4,7 +4,7 @@ const app = express();
 const port = 3001;
 
 // app.use(cors());
-app.use(express.static('public'));
+// app.use(express.static('public'));
 
 app.use((req, res, next) => {
   console.log(req.method);
@@ -27,4 +27,4 @@ app.get('/images', (req, res) => {
   res.json({ images: ['/images/kakao_muzi-con.png'] });
 });
 
-app.listen(port, () => console.log(`static-server listening at http://localhost:${port}`));
+app.listen(port, () => console.log(`api-server listening at http://localhost:${port}`));

--- a/front-server.js
+++ b/front-server.js
@@ -5,8 +5,4 @@ const port = 3000;
 app.use(express.static('public'));
 app.use(express.static('views'));
 
-// route
-app.get('/', (req, res) => res.render('index.html'));
-app.get('/images', (req, res) => res.json({ images: ['/images/kakao_tube.png'] }));
-
 app.listen(port, () => console.log(`front-server listening at http://localhost:${port}`));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start:front": "node front-server.js",
-    "start:api": "node static-server.js"
+    "start:api": "node api-server.js"
   },
   "keywords": [],
   "author": "",

--- a/public/images/index.html
+++ b/public/images/index.html
@@ -1,0 +1,1 @@
+Hello, world!

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -23,7 +23,7 @@ window.onload = function() {
       'Content-Type': 'application/json',
     });
 
-    fetch(`${STATIC_SERVER_URL}/images`, { method: 'GET', headers })
+    fetch(`${STATIC_SERVER_URL}/images/`, { method: 'GET', headers })
     .then(response => response.json())
     .then(({ images }) => {
       setImage(images[0]);

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -10,11 +10,7 @@ window.onload = function() {
   
   const button = document.querySelector('.content--image__button__same');
   button.addEventListener('click', () => {
-    fetch(`${MAIN_SERVER_URL}/images`)
-    .then(response => response.json())
-    .then(({ images }) => {
-      setImage(images[0]);
-    });
+    setImage("/images/kakao_tube.png")
   });
 
   const button2 = document.querySelector('.content--image__button__cross');
@@ -23,7 +19,7 @@ window.onload = function() {
       'Content-Type': 'application/json',
     });
 
-    fetch(`${STATIC_SERVER_URL}/images/`, { method: 'GET', headers })
+    fetch(`${STATIC_SERVER_URL}/images`, { method: 'GET', headers })
     .then(response => response.json())
     .then(({ images }) => {
       setImage(images[0]);


### PR DESCRIPTION
안녕하세요, 확인해봤는데 CORS문제는 아니었고 express에서 routing하는 과정에 문제가 있습니다.

`/images`로 요청하면 301 Move Permanently응답이 오고, `/images/`로 요청하니 정상적으로 이미지가 렌더링돼요.

```
❯ curl -v http://localhost:3001/images
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 3001 (#0)
> GET /images HTTP/1.1
> Host: localhost:3001
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< X-Powered-By: Express
< Content-Type: text/html; charset=UTF-8
< Content-Length: 179
< Content-Security-Policy: default-src 'none'
< X-Content-Type-Options: nosniff
< Location: /images/
< Date: Mon, 29 Jun 2020 13:30:26 GMT
< Connection: keep-alive
<
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Redirecting</title>
</head>
<body>
<pre>Redirecting to <a href="/images/">/images/</a></pre>
</body>
</html>
* Connection #0 to host localhost left intact
* Closing connection 0
```

```
❯ curl -v http://localhost:3001/images/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 3001 (#0)
> GET /images/ HTTP/1.1
> Host: localhost:3001
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Access-Control-Allow-Headers: Content-type
< Access-Control-Allow-Origin: http://localhost:3000
< Access-Control-Allow-Methods: GET,HEAD,PUT,PATCH,POST,DELETE
< Content-Type: application/json; charset=utf-8
< Content-Length: 41
< ETag: W/"29-g+PIPMtWqqsvr/4+AJZjKzSL9gc"
< Date: Mon, 29 Jun 2020 13:30:28 GMT
< Connection: keep-alive
<
* Connection #0 to host localhost left intact
{"images":["/images/kakao_muzi-con.png"]}* Closing connection 0
```

일단 정적(static) 파일 서버에 대해서 명확히 정의해야 할 것 같습니다. 정적 파일 서버는 말그대로 요청한 path에 해당하는 파일을 내보내주는 역할만 하는 서버입니다. `/images`처럼 trailing slash가 없는 경우는 `/images` 파일을, `/images/`처럼 trailing slash가 있는 경우는 `/images/index.html`을 내보냅니다.

따라서 이 프로젝트에서 스태틱 서버는 front-server.js라고 말할 수 있어요. public과 view 디렉토리를 root로 사용하니, 아래 request mapping이 없어도(그리고 없어야 정적 파일 서버입니다) 잘 동작합니다.

```
app.get('/', (req, res) => res.render('index.html'));
app.get('/images', (req, res) => res.json({ images: ['/images/kakao_tube.png'] }));
```

대신 `/images`요청에 대해서 `/images/index.html`파일을 내보내게 됩니다. 그게 `express.static` 미들웨어가 해주는 일이니까요. 301응답이 발생하는 이유는 `/images`가 파일이 아니라 디렉토리이기 때문에 디렉토리 path로 보내는 것입니다. fetch같은 비동기 요청이 아니라 a tag의 href가 `/images`였다면 `/images/`로 redirect됐겠죠. 그리고 `/images/index.html`파일의 내용이 보이게 됩니다.

```
❯ curl -v http://localhost:3000/images/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 3000 (#0)
> GET /images/ HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Accept-Ranges: bytes
< Cache-Control: public, max-age=0
< Last-Modified: Mon, 29 Jun 2020 13:47:51 GMT
< ETag: W/"d-1730055866c"
< Content-Type: text/html; charset=UTF-8
< Content-Length: 13
< Date: Mon, 29 Jun 2020 13:47:56 GMT
< Connection: keep-alive
<
* Connection #0 to host localhost left intact
Hello, world!* Closing connection 0
```

static-server.js는 정적 파일을 내보내는게 목적인 서버가 아니니 이름을 api-server.js 정도로 바꿔주면 적당할 것 같습니다.